### PR TITLE
Update pinata.ts

### DIFF
--- a/js/packages/cli/src/helpers/upload/pinata.ts
+++ b/js/packages/cli/src/helpers/upload/pinata.ts
@@ -3,6 +3,7 @@ import fetch from 'node-fetch';
 import FormData from 'form-data';
 import fs from 'fs';
 import { setImageUrlManifest } from './file-uri';
+import path from 'path';
 
 async function sleep(ms: number): Promise<void> {
   console.log('waiting');


### PR DESCRIPTION
When files are uploaded to pinata, use file name 0.json, 1.json etc, instead of tempJson.json.